### PR TITLE
Deploy: update image to ghcr.io/crothmeier/chat-exporter:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM mcr.microsoft.com/playwright:v1.40.0-focal
 WORKDIR /app
 RUN useradd -m scraper && chown -R scraper:scraper /app
+RUN apt-get update && apt-get install -y python3-pip && apt-get clean
 USER scraper
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 COPY scraper/ ./scraper/
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright PYTHONUNBUFFERED=1
 CMD ["python", "-m", "scraper.main"]

--- a/k8s/cronjob.yaml
+++ b/k8s/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
                 claimName: chat-exports-pvc
           containers:
             - name: exporter
-              image: chat-exporter:latest
+              image: registry.example.com/chat-exporter:latest
               env:
                 - name: OUTPUT_DIR
                   value: "/data/exports"


### PR DESCRIPTION
This updates the CronJob to pull the latest container from GHCR.