### PR TITLE
Fix filename collision

### DIFF
--- a/scraper/main.py
+++ b/scraper/main.py
@@ -36,7 +36,9 @@ def md_to_pdf(md_txt, out_path):
 
 def save(conv, base, plat):
     title = re.sub(r'[^\w\-]', '_', conv['title'])[:50]
-    ts = datetime.now().strftime('%H%M%S')
+    # Include microseconds to avoid filename collisions when multiple
+    # conversations are saved within the same second.
+    ts = datetime.now().strftime('%H%M%S_%f')
     fn = f'{title}_{ts}'
     json_path = base/plat/'json'/f'{fn}.json'
     md_path   = base/plat/'markdown'/f'{fn}.md'


### PR DESCRIPTION
## Summary
- avoid collisions when saving multiple chats in the same second

## Testing
- `python -m py_compile scraper/main.py`