### PR TITLE
Update export paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ venv:
 test-run:
 	python -m scraper.main --once
 outputs:
-	@echo "See ./_exports/`date +%F` for results"
+	@echo "See ${OUTPUT_DIR:-/tmp/exports}/`date +%F` for results"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ make venv
 make test-run  # local headless test
 ```
 
+## Output Directory
+Exports are written to `${OUTPUT_DIR:-/tmp/exports}/<date>/`. The `outputs` rule
+shows where today's export will be saved.
+
 See `k8s/` for deployment manifests and `.gitlab-ci.yml` for CI pipeline.
 
 _Generated 2025-05-21_


### PR DESCRIPTION
## Summary
- update Makefile outputs rule to show actual default path
- document OUTPUT_DIR behavior in README

## Testing
- `make test-run` *(fails: ModuleNotFoundError: No module named 'markdown')*