### PR TITLE
Implement continuous run loop

### DIFF
--- a/scraper/main.py
+++ b/scraper/main.py
@@ -64,4 +64,7 @@ if __name__ == '__main__':
     if args.once:
         run_once()
     else:
-        run_once()
+        while True:
+            run_once()
+            log.info('Sleeping for 24 hours before next export run')
+            time.sleep(86400)


### PR DESCRIPTION
## Summary
- implement infinite loop when `--once` isn't set

## Testing
- `make test-run` *(fails: ModuleNotFoundError: No module named 'markdown')*